### PR TITLE
[Hotfix] copyReference 에서 id 순으로 정렬 한 후 복사하도록 수정

### DIFF
--- a/app/src/features/reference/ui/CopyReferenceListButton.tsx
+++ b/app/src/features/reference/ui/CopyReferenceListButton.tsx
@@ -7,9 +7,11 @@ export const CopyReferenceListButton = () => {
   const { reference } = chromeStorage;
 
   const handleCopyReferenceList = () => {
-    const attachedReferences = reference.filter(
-      (data): data is AttachedReferenceData => data.isWritten
-    );
+    const attachedReferences = [
+      ...reference.filter(
+        (data): data is AttachedReferenceData => data.isWritten
+      ),
+    ].sort((a, b) => a.id - b.id);
 
     // 마크다운 모드라면 마크다운 문법에 맞게 anchor tag를 만들어줍니다.
     // 마크다운 모드가 아니라면 일반 텍스트로 만들어줍니다.


### PR DESCRIPTION
# 관련 이슈
close #43 
# 소요 시간 (1 뽀모 : 25분)
0 뽀모
# 작업 내용 

정렬 할 때 id 순으로 정렬 후 복사하는 것이 아닌 스택에 담긴 순으로 클립보드로 복사 되는 버그가 존재했습니다.

이에 클립보드에 복사 전 id 에 맞춰 정렬 한 후 클립 보드에 복사하도록 합니다. 

# 작업 시 겪은 이슈

# 관련 레퍼런스
