### PR TITLE
[Hotfix] manifest.json 에서 host_permissions 제거

### DIFF
--- a/app/src/manifest.json
+++ b/app/src/manifest.json
@@ -33,6 +33,5 @@
       "matches": ["https://velog.io/write*"],
       "js": ["src/autoConverting.ts"]
     }
-  ],
-  "host_permissions": ["<all_urls>"]
+  ]
 }


### PR DESCRIPTION
# 관련 이슈
close #47
# 소요 시간 (1 뽀모 : 25분)

1 뽀모

# 작업 내용 

host_permissions 를 제거 합니다. 

해당 권한이 필요한만큼 고급진 권한이 필요로 하지 않는 서비스입니다. 

> 이런 .. 1차로 배포했던것은  백퍼센트 반려되겠군요 


# 작업 시 겪은 이슈

# 관련 레퍼런스
