### PR TITLE
[Hotfix] 확장프로그램 초기 다운로드 시 크롬스토리지가 올바르게 초기화 되지 않는 버그 수정

### DIFF
--- a/app/src/background.ts
+++ b/app/src/background.ts
@@ -1,7 +1,8 @@
 import browser from "webextension-polyfill";
 import { convertNumberToReference } from "./features/reference/model";
+import { chromeStorageInitialValue } from "./shared/store";
 
-browser.runtime.onInstalled.addListener((details) => {
+browser.runtime.onInstalled.addListener(async (details) => {
   if (process.env.NODE_ENV === "development") {
     console.group("browser.runtime.onInstalled");
     console.dir(details);
@@ -11,6 +12,15 @@ browser.runtime.onInstalled.addListener((details) => {
     console.dir(browser.runtime.getManifest());
     console.groupEnd();
   }
+
+  // runtime.onInstalled 이벤트는 설치, 확장 프로그램 혹은 구글 크롬 업데이트 시 발생합니다.
+  // 이에 이전에 존재하던 스토리지 값과 기본 값을 이용해 크롬스토리지를 초기화합니다.
+
+  const prevStorageValue = await chrome.storage.sync.get(null);
+  chrome.storage.sync.set({
+    ...chromeStorageInitialValue,
+    ...prevStorageValue,
+  });
 });
 
 const notifyError = (message: string) => {

--- a/app/src/manifest.json
+++ b/app/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RefNote",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "블로깅에 필요한 레퍼런스들을 가볍고 편하게 저장 및 사용 할 수 있는 확장 프로그램입니다.",
   "minimum_chrome_version": "116",
   "{{chrome}}.manifest_version": 3,

--- a/app/src/shared/store/chromeStorage.tsx
+++ b/app/src/shared/store/chromeStorage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, createContext, useContext, useRef } from "react";
 
-const chromeStorageInitialValue: ChromeStorage = {
+export const chromeStorageInitialValue: ChromeStorage = {
   reference: [],
   autoConverting: false,
   isDarkMode: false,

--- a/app/src/shared/store/chromeStorage.tsx
+++ b/app/src/shared/store/chromeStorage.tsx
@@ -47,14 +47,10 @@ export const ChromeStorageProvider = ({
       _syncChromeStorage(updatedChromeStorage as ChromeStorage);
     };
 
-    // chrome.storage.sync.get 을 통해 chrome.storage.sync 의 데이터를 가져옵니다.
-    chrome.storage.sync.get(chromeStorageInitialValue, (data) => {
-      if (Object.keys(data).length > 0) {
-        _syncChromeStorage(data as ChromeStorage);
-      } else {
-        chrome.storage.sync.set(chromeStorageInitialValue);
-      }
-    });
+    chrome.storage.sync.get(null, (chromeStorage) =>
+      _syncChromeStorage(chromeStorage as ChromeStorage)
+    );
+
     chrome.storage.onChanged.addListener(synchronizeChromeStorage);
 
     /**


### PR DESCRIPTION
# 관련 이슈
close #59 
# 소요 시간 (1 뽀모 : 25분)
1뽀모
# 작업 내용 

개발자 모드에서 한 번 크롬 스토리지 값을 초기화 한 경우에 발견하지 못했던 버그인데 

현재 배포되어있는 1.1.0 버전으 실제로 다운 받아 사용해보니 `reference` 배열이 초기 생성 되기 전 까지는 다른 상태를 설정하지 못하는 버그가 존재했습니다. 

이에 확장프로그램 인스톨 시 바로 크롬스토리지를 초기화 해두는 코드를 `chrome.runtime.onInstalled` 에 추가해줬습니다. 

# 작업 시 겪은 이슈

# 관련 레퍼런스
