### PR TITLE
[Feat] 글에 첨부되지 않은 레퍼런스 목록 접기/펼치기 기능 추가

### DIFF
--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -33,6 +33,7 @@ declare global {
     reference: ReferenceData[];
     autoConverting: boolean;
     isDarkMode: boolean;
+    unAttachedIsVisible: boolean;
   }
 
   interface Tab extends chrome.tabs.Tab {

--- a/app/src/features/reference/ui/AttachedReferenceList.tsx
+++ b/app/src/features/reference/ui/AttachedReferenceList.tsx
@@ -2,6 +2,7 @@ import { useTab } from "@/shared/store";
 import { ReferenceItem } from "./ReferenceItem";
 import { useEffect, useState } from "react";
 import { sendConvertReferenceMessage } from "../model";
+import styles from "./styles.module.css";
 
 interface AttachedReferenceListProps {
   attachedReferenceList: AttachedReferenceData[];
@@ -21,7 +22,7 @@ export const AttachedReferenceList = ({
   }, [attachedReferenceList]);
 
   return (
-    <ul>
+    <ul className={styles.referenceList}>
       {attachedReferenceList
         .sort((prev, cur) => prev.id - cur.id)
         .map((reference, idx) => (

--- a/app/src/features/reference/ui/AttachedReferenceList.tsx
+++ b/app/src/features/reference/ui/AttachedReferenceList.tsx
@@ -1,12 +1,16 @@
-import { useChromeStorage, useTab } from "@/shared/store";
+import { useTab } from "@/shared/store";
 import { ReferenceItem } from "./ReferenceItem";
 import { useEffect, useState } from "react";
 import { sendConvertReferenceMessage } from "../model";
 
-export const AttachedReferenceList = () => {
+interface AttachedReferenceListProps {
+  attachedReferenceList: AttachedReferenceData[];
+}
+
+export const AttachedReferenceList = ({
+  attachedReferenceList,
+}: AttachedReferenceListProps) => {
   const [activeUrl, setIsActiveUrl] = useState<string>("");
-  const { chromeStorage } = useChromeStorage();
-  const { reference } = chromeStorage;
   const tab = useTab();
 
   useEffect(() => {
@@ -14,12 +18,11 @@ export const AttachedReferenceList = () => {
       return;
     }
     sendConvertReferenceMessage();
-  }, [reference]);
+  }, [attachedReferenceList]);
 
   return (
     <ul>
-      {reference
-        .filter((data): data is AttachedReferenceData => data.isWritten)
+      {attachedReferenceList
         .sort((prev, cur) => prev.id - cur.id)
         .map((reference, idx) => (
           <li key={idx}>

--- a/app/src/features/reference/ui/CopyReferenceListButton.tsx
+++ b/app/src/features/reference/ui/CopyReferenceListButton.tsx
@@ -1,17 +1,17 @@
-import { useChromeStorage } from "@/shared/store";
 import { Button } from "@/shared/ui/button";
 import styles from "./styles.module.css";
 
-export const CopyReferenceListButton = () => {
-  const { chromeStorage } = useChromeStorage();
-  const { reference } = chromeStorage;
+interface CopyReferenceListButtonProps {
+  attachedReferenceList: AttachedReferenceData[];
+}
 
+export const CopyReferenceListButton = ({
+  attachedReferenceList,
+}: CopyReferenceListButtonProps) => {
   const handleCopyReferenceList = () => {
-    const attachedReferences = [
-      ...reference.filter(
-        (data): data is AttachedReferenceData => data.isWritten
-      ),
-    ].sort((a, b) => a.id - b.id);
+    const attachedReferences = [...attachedReferenceList].sort(
+      (a, b) => a.id - b.id
+    );
 
     const result = attachedReferences.map(
       ({ title, url, id }) => `[${id}. ${title}](${url})`
@@ -25,7 +25,7 @@ export const CopyReferenceListButton = () => {
         type: "basic",
         iconUrl: "/icon/128.png",
         title: "복사 완료",
-        message: `${reference.filter(({ isWritten }) => isWritten).length} 개의 레퍼런스 목록이 복사되었습니다.`,
+        message: `${attachedReferenceList.length} 개의 레퍼런스 목록이 복사되었습니다.`,
         silent: true,
       },
       () => {

--- a/app/src/features/reference/ui/UnAttachedReferenceList.tsx
+++ b/app/src/features/reference/ui/UnAttachedReferenceList.tsx
@@ -1,29 +1,28 @@
-import { useChromeStorage } from "@/shared/store";
 import { ReferenceItem } from "./ReferenceItem";
 import { useState } from "react";
 
-export const UnAttachedReferenceList = () => {
+interface UnAttachedReferenceListProps {
+  unAttachedReferenceList: UnAttachedReferenceData[];
+}
+
+export const UnAttachedReferenceList = ({
+  unAttachedReferenceList,
+}: UnAttachedReferenceListProps) => {
   const [activeUrl, setIsActiveUrl] = useState<string>("");
-  const { chromeStorage } = useChromeStorage();
-  const { reference } = chromeStorage;
 
   return (
     <ul>
-      {reference
-        .filter((data): data is UnAttachedReferenceData => !data.isWritten)
-        .map((reference, idx) => (
-          <li key={idx}>
-            <ReferenceItem
-              {...reference}
-              isActive={activeUrl === reference.url}
-              onClick={() => {
-                setIsActiveUrl(
-                  activeUrl === reference.url ? "" : reference.url
-                );
-              }}
-            />
-          </li>
-        ))}
+      {unAttachedReferenceList.map((reference, idx) => (
+        <li key={idx}>
+          <ReferenceItem
+            {...reference}
+            isActive={activeUrl === reference.url}
+            onClick={() => {
+              setIsActiveUrl(activeUrl === reference.url ? "" : reference.url);
+            }}
+          />
+        </li>
+      ))}
     </ul>
   );
 };

--- a/app/src/features/reference/ui/UnAttachedReferenceList.tsx
+++ b/app/src/features/reference/ui/UnAttachedReferenceList.tsx
@@ -1,5 +1,6 @@
 import { ReferenceItem } from "./ReferenceItem";
 import { useState } from "react";
+import styles from "./styles.module.css";
 
 interface UnAttachedReferenceListProps {
   unAttachedReferenceList: UnAttachedReferenceData[];
@@ -11,7 +12,7 @@ export const UnAttachedReferenceList = ({
   const [activeUrl, setIsActiveUrl] = useState<string>("");
 
   return (
-    <ul>
+    <ul className={styles.referenceList}>
       {unAttachedReferenceList.map((reference, idx) => (
         <li key={idx}>
           <ReferenceItem

--- a/app/src/features/reference/ui/styles.module.css
+++ b/app/src/features/reference/ui/styles.module.css
@@ -204,3 +204,10 @@
   flex-grow: 1;
   flex-shrink: 0;
 }
+
+.referenceList {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  overflow-y: scroll;
+}

--- a/app/src/pages/SidePanel.tsx
+++ b/app/src/pages/SidePanel.tsx
@@ -1,15 +1,15 @@
 import {
-  AttachedReferenceList,
   ConvertToReferenceButton,
-  CopyReferenceListButton,
   ReferenceSaveButton,
   ResetReferenceButton,
-  UnAttachedReferenceList,
 } from "@/features/reference/ui";
 import { useChromeStorage } from "@/shared/store/chromeStorage";
-import { AutoConvertingToggle } from "@/features/reference/ui";
 import { DarkModeToggle } from "@/features/utils/ui";
 import styles from "./pages.module.css";
+import {
+  AttachedReferenceContainer,
+  UnAttachedReferenceContainer,
+} from "@/widgets/reference/ui";
 
 export const SidePanelPage = () => {
   const { chromeStorage } = useChromeStorage();
@@ -17,42 +17,23 @@ export const SidePanelPage = () => {
 
   return (
     <>
-      <header className={styles.headerButtonContainer}>
+      <header className={styles.buttonContainer}>
         <ReferenceSaveButton />
         <DarkModeToggle />
       </header>
       <main>
-        <section className={styles.referenceContainer}>
-          <h2>
-            글에 첨부되지 않은 레퍼런스
-            <span>
-              ({reference.filter(({ isWritten }) => !isWritten).length})
-            </span>
-          </h2>
-          <UnAttachedReferenceList />
-        </section>
-        <section className={styles.referenceContainer}>
-          <div
-            className={styles.headerButtonContainer}
-            style={{
-              marginBottom: "0.5rem",
-            }}
-          >
-            <h2>
-              글에 첨부된 레퍼런스
-              <span>
-                ({reference.filter(({ isWritten }) => isWritten).length})
-              </span>
-            </h2>
-            <AutoConvertingToggle />
-          </div>
-          <div className={styles.headerButtonContainer}>
-            <CopyReferenceListButton />
-          </div>
-          <AttachedReferenceList />
-        </section>
+        <UnAttachedReferenceContainer
+          reference={reference.filter(
+            (data): data is UnAttachedReferenceData => !data.isWritten
+          )}
+        />
+        <AttachedReferenceContainer
+          reference={reference.filter(
+            (data): data is AttachedReferenceData => data.isWritten
+          )}
+        />
       </main>
-      <footer className={styles.headerButtonContainer}>
+      <footer className={styles.buttonContainer}>
         <ConvertToReferenceButton />
         <ResetReferenceButton />
       </footer>

--- a/app/src/pages/SidePanel.tsx
+++ b/app/src/pages/SidePanel.tsx
@@ -15,6 +15,14 @@ export const SidePanelPage = () => {
   const { chromeStorage } = useChromeStorage();
   const { reference } = chromeStorage;
 
+  const unAttachedReferenceList = reference.filter(
+    (data): data is UnAttachedReferenceData => !data.isWritten
+  );
+
+  const attachedReferenceList = reference.filter(
+    (data): data is AttachedReferenceData => data.isWritten
+  );
+
   return (
     <>
       <header className={styles.buttonContainer}>
@@ -23,14 +31,10 @@ export const SidePanelPage = () => {
       </header>
       <main>
         <UnAttachedReferenceContainer
-          reference={reference.filter(
-            (data): data is UnAttachedReferenceData => !data.isWritten
-          )}
+          unAttachedReferenceList={unAttachedReferenceList}
         />
         <AttachedReferenceContainer
-          reference={reference.filter(
-            (data): data is AttachedReferenceData => data.isWritten
-          )}
+          attachedReferenceList={attachedReferenceList}
         />
       </main>
       <footer className={styles.buttonContainer}>

--- a/app/src/pages/pages.module.css
+++ b/app/src/pages/pages.module.css
@@ -1,30 +1,6 @@
-.headerButtonContainer {
+.buttonContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
-}
-
-.referenceContainer {
-  display: flex;
-  flex-direction: column;
-  height: 50%;
-}
-
-.referenceContainer > ul {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  overflow-y: scroll;
-}
-
-.flexBetweenCenter {
-  display: flex;
-  gap: 0.5rem;
-}
-
-h2 > span {
-  font-size: 0.8rem;
-  color: #a0a0a0;
-  margin-left: 4px;
 }

--- a/app/src/shared/store/chromeStorage.tsx
+++ b/app/src/shared/store/chromeStorage.tsx
@@ -4,6 +4,7 @@ export const chromeStorageInitialValue: ChromeStorage = {
   reference: [],
   autoConverting: false,
   isDarkMode: false,
+  unAttachedIsVisible: true,
 };
 
 const ChromeStorageContext = createContext<{

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -52,4 +52,6 @@ header {
 
 main {
   flex-grow: 1;
+  display: flex;
+  flex-direction: column;
 }

--- a/app/src/widgets/reference/ui/AttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/AttachedReferenceContainer.tsx
@@ -19,9 +19,9 @@ export const AttachedReferenceContainer = ({
         <AutoConvertingToggle />
       </div>
       <div>
-        <CopyReferenceListButton />
+        <CopyReferenceListButton attachedReferenceList={reference} />
       </div>
-      <AttachedReferenceList />
+      <AttachedReferenceList attachedReferenceList={reference} />
     </section>
   );
 };

--- a/app/src/widgets/reference/ui/AttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/AttachedReferenceContainer.tsx
@@ -1,0 +1,27 @@
+import type { ReferenceContainerProps } from "./types";
+import styles from "./reference.module.css";
+import {
+  AutoConvertingToggle,
+  CopyReferenceListButton,
+  AttachedReferenceList,
+} from "@/features/reference/ui";
+
+export const AttachedReferenceContainer = ({
+  reference,
+}: ReferenceContainerProps<AttachedReferenceData>) => {
+  return (
+    <section className={styles.referenceContainer}>
+      <div>
+        <h2>
+          글에 첨부된 레퍼런스
+          <span>({reference.length})</span>
+        </h2>
+        <AutoConvertingToggle />
+      </div>
+      <div>
+        <CopyReferenceListButton />
+      </div>
+      <AttachedReferenceList />
+    </section>
+  );
+};

--- a/app/src/widgets/reference/ui/AttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/AttachedReferenceContainer.tsx
@@ -1,4 +1,3 @@
-import type { ReferenceContainerProps } from "./types";
 import styles from "./reference.module.css";
 import {
   AutoConvertingToggle,
@@ -6,22 +5,28 @@ import {
   AttachedReferenceList,
 } from "@/features/reference/ui";
 
+interface AttachedReferenceContainerProps {
+  attachedReferenceList: AttachedReferenceData[];
+}
+
 export const AttachedReferenceContainer = ({
-  reference,
-}: ReferenceContainerProps<AttachedReferenceData>) => {
+  attachedReferenceList,
+}: AttachedReferenceContainerProps) => {
   return (
     <section className={styles.referenceContainer}>
       <div>
         <h2>
           글에 첨부된 레퍼런스
-          <span>({reference.length})</span>
+          <span>({attachedReferenceList.length})</span>
         </h2>
         <AutoConvertingToggle />
       </div>
       <div>
-        <CopyReferenceListButton attachedReferenceList={reference} />
+        <CopyReferenceListButton
+          attachedReferenceList={attachedReferenceList}
+        />
       </div>
-      <AttachedReferenceList attachedReferenceList={reference} />
+      <AttachedReferenceList attachedReferenceList={attachedReferenceList} />
     </section>
   );
 };

--- a/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
@@ -32,9 +32,13 @@ export const UnAttachedReferenceContainer = ({
               unAttachedIsVisible: !unAttachedIsVisible,
             }));
           }}
-          className={styles.foldButton}
+          aria-label={
+            unAttachedIsVisible
+              ? "글에 첨부하지 않은 레퍼런스 리스트 목록 보기"
+              : "글에 첨부하지 않은 레퍼런스 리스트 목록 숨기기"
+          }
         >
-          {unAttachedIsVisible ? "접기" : "펼치기"}
+          {unAttachedIsVisible ? "▲" : "▼"}
         </Button>
       </div>
       {unAttachedIsVisible && (

--- a/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import styles from "./reference.module.css";
 import { UnAttachedReferenceList } from "@/features/reference/ui";
 import { Button } from "@/shared/ui/button";
+import { useChromeStorage } from "@/shared/store";
 
 interface UnAttachedReferenceContainerProps {
   unAttachedReferenceList: UnAttachedReferenceData[];
@@ -10,12 +11,14 @@ interface UnAttachedReferenceContainerProps {
 export const UnAttachedReferenceContainer = ({
   unAttachedReferenceList,
 }: UnAttachedReferenceContainerProps) => {
-  const [unAttachedReferenceListVisible, setUnAttachedReferenceListVisible] =
-    useState<boolean>(false);
+  const {
+    chromeStorage: { unAttachedIsVisible },
+    setChromeStorage,
+  } = useChromeStorage();
 
   return (
     <section
-      className={`${styles.referenceContainer} ${unAttachedReferenceListVisible ? "" : styles.folded}`}
+      className={`${styles.referenceContainer} ${unAttachedIsVisible ? "" : styles.folded}`}
     >
       <div>
         <h2>
@@ -24,14 +27,17 @@ export const UnAttachedReferenceContainer = ({
         </h2>
         <Button
           onClick={() => {
-            setUnAttachedReferenceListVisible((prev) => !prev);
+            setChromeStorage((prev) => ({
+              ...prev,
+              unAttachedIsVisible: !unAttachedIsVisible,
+            }));
           }}
           className={styles.foldButton}
         >
-          {unAttachedReferenceListVisible ? "접기" : "펼치기"}
+          {unAttachedIsVisible ? "접기" : "펼치기"}
         </Button>
       </div>
-      {unAttachedReferenceListVisible && (
+      {unAttachedIsVisible && (
         <UnAttachedReferenceList
           unAttachedReferenceList={unAttachedReferenceList}
         />

--- a/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
@@ -1,17 +1,22 @@
 import styles from "./reference.module.css";
 import { UnAttachedReferenceList } from "@/features/reference/ui";
-import type { ReferenceContainerProps } from "./types";
+
+interface UnAttachedReferenceContainerProps {
+  unAttachedReferenceList: UnAttachedReferenceData[];
+}
 
 export const UnAttachedReferenceContainer = ({
-  reference,
-}: ReferenceContainerProps<UnAttachedReferenceData>) => {
+  unAttachedReferenceList,
+}: UnAttachedReferenceContainerProps) => {
   return (
     <section className={styles.referenceContainer}>
       <h2>
         글에 첨부되지 않은 레퍼런스
-        <span>({reference.length})</span>
+        <span>({unAttachedReferenceList.length})</span>
       </h2>
-      <UnAttachedReferenceList unAttachedReferenceList={reference} />
+      <UnAttachedReferenceList
+        unAttachedReferenceList={unAttachedReferenceList}
+      />
     </section>
   );
 };

--- a/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
@@ -11,7 +11,7 @@ export const UnAttachedReferenceContainer = ({
         글에 첨부되지 않은 레퍼런스
         <span>({reference.length})</span>
       </h2>
-      <UnAttachedReferenceList />
+      <UnAttachedReferenceList unAttachedReferenceList={reference} />
     </section>
   );
 };

--- a/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
@@ -1,0 +1,17 @@
+import styles from "./reference.module.css";
+import { UnAttachedReferenceList } from "@/features/reference/ui";
+import type { ReferenceContainerProps } from "./types";
+
+export const UnAttachedReferenceContainer = ({
+  reference,
+}: ReferenceContainerProps<UnAttachedReferenceData>) => {
+  return (
+    <section className={styles.referenceContainer}>
+      <h2>
+        글에 첨부되지 않은 레퍼런스
+        <span>({reference.length})</span>
+      </h2>
+      <UnAttachedReferenceList />
+    </section>
+  );
+};

--- a/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
+++ b/app/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import styles from "./reference.module.css";
 import { UnAttachedReferenceList } from "@/features/reference/ui";
+import { Button } from "@/shared/ui/button";
 
 interface UnAttachedReferenceContainerProps {
   unAttachedReferenceList: UnAttachedReferenceData[];
@@ -8,15 +10,32 @@ interface UnAttachedReferenceContainerProps {
 export const UnAttachedReferenceContainer = ({
   unAttachedReferenceList,
 }: UnAttachedReferenceContainerProps) => {
+  const [unAttachedReferenceListVisible, setUnAttachedReferenceListVisible] =
+    useState<boolean>(false);
+
   return (
-    <section className={styles.referenceContainer}>
-      <h2>
-        글에 첨부되지 않은 레퍼런스
-        <span>({unAttachedReferenceList.length})</span>
-      </h2>
-      <UnAttachedReferenceList
-        unAttachedReferenceList={unAttachedReferenceList}
-      />
+    <section
+      className={`${styles.referenceContainer} ${unAttachedReferenceListVisible ? "" : styles.folded}`}
+    >
+      <div>
+        <h2>
+          글에 첨부되지 않은 레퍼런스
+          <span>({unAttachedReferenceList.length})</span>
+        </h2>
+        <Button
+          onClick={() => {
+            setUnAttachedReferenceListVisible((prev) => !prev);
+          }}
+          className={styles.foldButton}
+        >
+          {unAttachedReferenceListVisible ? "접기" : "펼치기"}
+        </Button>
+      </div>
+      {unAttachedReferenceListVisible && (
+        <UnAttachedReferenceList
+          unAttachedReferenceList={unAttachedReferenceList}
+        />
+      )}
     </section>
   );
 };

--- a/app/src/widgets/reference/ui/index.ts
+++ b/app/src/widgets/reference/ui/index.ts
@@ -1,0 +1,2 @@
+export * from "./AttachedReferenceContainer";
+export * from "./UnAttachedReferenceContainer";

--- a/app/src/widgets/reference/ui/reference.module.css
+++ b/app/src/widgets/reference/ui/reference.module.css
@@ -5,13 +5,6 @@
   flex-basis: 50%;
 }
 
-.referenceContainer > ul {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  overflow-y: scroll;
-}
-
 .referenceContainer > div {
   display: flex;
   justify-content: space-between;

--- a/app/src/widgets/reference/ui/reference.module.css
+++ b/app/src/widgets/reference/ui/reference.module.css
@@ -1,7 +1,8 @@
 .referenceContainer {
   display: flex;
   flex-direction: column;
-  height: 50%;
+  flex-grow: 1;
+  flex-basis: 50%;
 }
 
 .referenceContainer > ul {
@@ -26,4 +27,14 @@
   font-size: 0.8rem;
   color: #a0a0a0;
   margin-left: 4px;
+}
+
+.folded {
+  flex-basis: 0;
+  flex-grow: 0;
+  margin-bottom: 1rem;
+}
+
+.foldButton {
+  min-width: 5rem;
 }

--- a/app/src/widgets/reference/ui/reference.module.css
+++ b/app/src/widgets/reference/ui/reference.module.css
@@ -1,0 +1,29 @@
+.referenceContainer {
+  display: flex;
+  flex-direction: column;
+  height: 50%;
+}
+
+.referenceContainer > ul {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  overflow-y: scroll;
+}
+
+.referenceContainer > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.referenceContainer > div:nth-child(1) {
+  margin-bottom: 0.5rem;
+}
+
+.referenceContainer h2 > span {
+  font-size: 0.8rem;
+  color: #a0a0a0;
+  margin-left: 4px;
+}

--- a/app/src/widgets/reference/ui/types.ts
+++ b/app/src/widgets/reference/ui/types.ts
@@ -1,3 +1,0 @@
-export interface ReferenceContainerProps<T extends ReferenceData> {
-  reference: T[];
-}

--- a/app/src/widgets/reference/ui/types.ts
+++ b/app/src/widgets/reference/ui/types.ts
@@ -1,0 +1,3 @@
+export interface ReferenceContainerProps<T extends ReferenceData> {
+  reference: T[];
+}


### PR DESCRIPTION
# 관련 이슈
close #61 
# 소요 시간 (1 뽀모 : 25분)
2 뽀모

# 작업 내용 

![fold gif](https://github.com/user-attachments/assets/a6873d64-f02b-4798-a124-ae70dc3879ee)

글에 첨부하지 않은 레퍼런스 목록 접기, 펼치기 버튼을 생성했습니다. 

이 과정에서 `widget` 레이어를 생성하여 사이드패널 페이지 컴포넌트의 형태를 더욱 간략하게 수정했습니다. 

```tsx
  return (
    <>
      <header className={styles.buttonContainer}>
        <ReferenceSaveButton />
        <DarkModeToggle />
      </header>
      <main>
         // widget 에서 내부 아이템 정의 
        <UnAttachedReferenceContainer
          unAttachedReferenceList={unAttachedReferenceList}
        />
         // widget 에서 내부 아이템 정의 
        <AttachedReferenceContainer
          attachedReferenceList={attachedReferenceList}
        />
      </main>
      <footer className={styles.buttonContainer}>
        <ConvertToReferenceButton />
        <ResetReferenceButton />
      </footer>
    </>
  );
```

# 작업 시 겪은 이슈

# 관련 레퍼런스
