### PR TITLE
[Feat] IconButton radius, ReferenceItem border bottom 스타일 변경

### DIFF
--- a/app/src/features/reference/ui/styles.module.css
+++ b/app/src/features/reference/ui/styles.module.css
@@ -1,5 +1,5 @@
 .container {
-  border-bottom: 1px dashed #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
 }
 
 .container > div:nth-child(1) {

--- a/app/src/shared/ui/button/Button.module.css
+++ b/app/src/shared/ui/button/Button.module.css
@@ -39,6 +39,6 @@
   align-items: center;
   border: none;
   background-color: #f0f0f0;
-  border-radius: 2rem;
+  border-radius: 4px;
   cursor: pointer;
 }


### PR DESCRIPTION
# 관련 이슈
close #80
# 소요 시간 (1 뽀모 : 25분)
0.1뽀모
# 작업 내용 

`IconButton` 의 border radius 를 줄이고 밑줄 스타일을 dashed가 아닌 solid로 변경합니다. 

얘가 더 깔끔해보이는 느낌

![image](https://github.com/user-attachments/assets/a38af2b5-11d6-4ff2-8a05-da251cb55655)

![image](https://github.com/user-attachments/assets/2629170a-1fe8-4a69-90fa-e942be6bc899)

# 작업 시 겪은 이슈

# 관련 레퍼런스
