### PR TITLE
[Feat] 목록 복사 버튼 하단 Footer 영역으로 이동시켜 글에 첨부된 레퍼런스 목록 높이 증가 

### DIFF
--- a/extension/src/features/reference/ui/ConvertToReferenceButton.tsx
+++ b/extension/src/features/reference/ui/ConvertToReferenceButton.tsx
@@ -41,7 +41,7 @@ export const ConvertToReferenceButton = () => {
       className="flex-grow"
       disabled={!(isVelogWritePage && chromeStorage.isContentScriptEnabled)}
     >
-      텍스트 전환
+      텍스트 변환
     </Button>
   );
 };

--- a/extension/src/features/reference/ui/CopyReferenceListButton.tsx
+++ b/extension/src/features/reference/ui/CopyReferenceListButton.tsx
@@ -1,16 +1,15 @@
+import { useChromeStorage } from "@/shared/store";
 import { Button } from "@/shared/ui/button";
 
-interface CopyReferenceListButtonProps {
-  attachedReferenceList: AttachedReferenceData[];
-}
+export const CopyReferenceListButton = () => {
+  const {
+    chromeStorage: { reference },
+  } = useChromeStorage();
 
-export const CopyReferenceListButton = ({
-  attachedReferenceList,
-}: CopyReferenceListButtonProps) => {
   const handleCopyReferenceList = () => {
-    const attachedReferences = [...attachedReferenceList].sort(
-      (a, b) => a.id - b.id
-    );
+    const attachedReferences = reference
+      .filter((data) => data.isWritten)
+      .sort((a, b) => a.id - b.id);
 
     const result = attachedReferences.map(
       ({ title, url, id }) => `${id}. [${title}](${url})`
@@ -24,7 +23,7 @@ export const CopyReferenceListButton = ({
         type: "basic",
         iconUrl: "/icon/128.png",
         title: "복사 완료",
-        message: `${attachedReferenceList.length} 개의 레퍼런스 목록이 복사되었습니다.`,
+        message: `${attachedReferences.length} 개의 레퍼런스 목록이 복사되었습니다.`,
         silent: true,
       },
       () => {
@@ -36,7 +35,7 @@ export const CopyReferenceListButton = ({
   };
 
   return (
-    <Button onClick={handleCopyReferenceList} className="w-full">
+    <Button onClick={handleCopyReferenceList} className="flex-grow">
       목록 복사
     </Button>
   );

--- a/extension/src/pages/SidePanel.tsx
+++ b/extension/src/pages/SidePanel.tsx
@@ -1,5 +1,6 @@
 import {
   ConvertToReferenceButton,
+  CopyReferenceListButton,
   ReferenceSaveButton,
   ResetReferenceButton,
 } from "@/features/reference/ui";
@@ -21,6 +22,7 @@ export const SidePanelPage = () => {
         <AttachedReferenceContainer />
       </main>
       <footer className="flex justify-center items-center gap-4">
+        <CopyReferenceListButton />
         <ConvertToReferenceButton />
         <ResetReferenceButton />
       </footer>

--- a/extension/src/widgets/reference/ui/AttachedReferenceContainer.tsx
+++ b/extension/src/widgets/reference/ui/AttachedReferenceContainer.tsx
@@ -1,7 +1,6 @@
 import { useChromeStorage, useTab } from "@/shared/store";
 import {
   AutoConvertingToggle,
-  CopyReferenceListButton,
   AttachedReferenceList,
 } from "@/features/reference/ui";
 import { ContentScriptErrorButton } from "@/features/utils/ui";
@@ -16,7 +15,8 @@ export const AttachedReferenceContainer = () => {
   } = useChromeStorage();
   const tab = useTab();
 
-  const isVelogWritePage = tab?.url.includes("https://velog.io/write");
+  const isError =
+    tab?.url.includes("https://velog.io/write") && !isContentScriptEnabled;
 
   const attachedReferenceList = reference.filter(
     (data): data is AttachedReferenceData => data.isWritten
@@ -37,15 +37,7 @@ export const AttachedReferenceContainer = () => {
         </h2>
         <AutoConvertingToggle />
       </div>
-      <div>
-        {isVelogWritePage && !isContentScriptEnabled ? (
-          <ContentScriptErrorButton tab={tab} />
-        ) : (
-          <CopyReferenceListButton
-            attachedReferenceList={attachedReferenceList}
-          />
-        )}
-      </div>
+      {isError && <ContentScriptErrorButton tab={tab} />}
       <AttachedReferenceList attachedReferenceList={attachedReferenceList} />
     </section>
   );


### PR DESCRIPTION
# 관련 이슈

close #87

# 소요 시간 (1 뽀모 : 25분)

1뽀모

# 작업 내용 

![image](https://github.com/user-attachments/assets/c9d20809-02c8-4b68-a75b-8790e324eb58)

- 텍스트 전환 -> 텍스트 변환 으로 텍스트 수정 
- 목록 복사 버튼 AttachedReferenceContainer 에서 Footer 영역으로 이동

# 작업 시 겪은 이슈

# 관련 레퍼런스
