### PR TITLE
[Feat] 사용 가능 용량을 알리기 위한 상단 status bar 생성

### DIFF
--- a/extension/src/features/utils/ui/StorageVolumeBar.tsx
+++ b/extension/src/features/utils/ui/StorageVolumeBar.tsx
@@ -36,7 +36,7 @@ export const StorageVolumeBar = () => {
           style={{ width: `${percentageOfUsed}%` }}
         />
       </div>
-      <span className="w-8 text-end">{percentageOfUsed} %</span>
+      <span className="w-8 text-end text-primary">{percentageOfUsed} %</span>
     </div>
   );
 };

--- a/extension/src/features/utils/ui/StorageVolumeBar.tsx
+++ b/extension/src/features/utils/ui/StorageVolumeBar.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+/**
+ * chrome.storage.sync 의 경우 각 key 별 저장 가능한 최대 크기가 8kb 입니다.
+ * 이에 사용 가능 reference를 기준으로 하여 사용량을 표시하는 컴포넌트입니다.
+ */
+export const StorageVolumeBar = () => {
+  const [usedBytes, setUsedBytes] = useState<number>(0);
+  const availableBytes = 8 * 1024; //  8kb
+  const percentageOfUsed = Math.round((usedBytes / availableBytes) * 100);
+
+  useEffect(() => {
+    const updateStorageUsage = () => {
+      chrome.storage.sync.getBytesInUse("reference", (bytesInUse) => {
+        setUsedBytes(bytesInUse);
+      });
+    };
+
+    // 초기 용량 업데이트
+    updateStorageUsage();
+
+    // 스토리지 변경 감지
+    chrome.storage.sync.onChanged.addListener(updateStorageUsage);
+
+    // 클린업 함수
+    return () => {
+      chrome.storage.sync.onChanged.removeListener(updateStorageUsage);
+    };
+  }, []);
+
+  return (
+    <div className="flex gap-2 items-center">
+      <div className="flex-grow bg-gray-200 h-1 rounded-md ">
+        <div
+          className="h-full rounded-md bg-primary"
+          style={{ width: `${percentageOfUsed}%` }}
+        />
+      </div>
+      <span className="w-8 text-end">{percentageOfUsed} %</span>
+    </div>
+  );
+};

--- a/extension/src/features/utils/ui/StorageVolumeBar.tsx
+++ b/extension/src/features/utils/ui/StorageVolumeBar.tsx
@@ -32,7 +32,7 @@ export const StorageVolumeBar = () => {
     <div className="flex gap-2 items-center">
       <div className="flex-grow bg-gray-200 h-1 rounded-md ">
         <div
-          className="h-full rounded-md bg-primary"
+          className="h-full rounded-md bg-primary transition-[width] duration-300"
           style={{ width: `${percentageOfUsed}%` }}
         />
       </div>

--- a/extension/src/features/utils/ui/index.ts
+++ b/extension/src/features/utils/ui/index.ts
@@ -1,1 +1,2 @@
 export * from "./DarkModeToggle";
+export * from "./StorageVolumeBar";

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RefNote",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "블로깅에 필요한 레퍼런스들을 가볍고 편하게 저장 및 사용 할 수 있는 확장 프로그램입니다.",
   "minimum_chrome_version": "116",
   "{{chrome}}.manifest_version": 3,

--- a/extension/src/pages/SidePanel.tsx
+++ b/extension/src/pages/SidePanel.tsx
@@ -8,15 +8,18 @@ import {
   ReferenceSaveButton,
   ResetReferenceButton,
 } from "@/features/reference/ui";
-import { DarkModeToggle } from "@/features/utils/ui";
+import { DarkModeToggle, StorageVolumeBar } from "@/features/utils/ui";
 import { UnExpectedErrorBoundary } from "./errorBoundary";
 
 export const SidePanelPage = () => {
   return (
     <UnExpectedErrorBoundary>
-      <header className="flex justify-between items-center pb-2 gap-4 ">
-        <ReferenceSaveButton />
-        <DarkModeToggle />
+      <header className="flex flex-col pb-2 gap-2 ">
+        <div className="flex gap-4">
+          <ReferenceSaveButton />
+          <DarkModeToggle />
+        </div>
+        <StorageVolumeBar />
       </header>
       <main className="flex flex-col h-full gap-2">
         <UnAttachedReferenceContainer />

--- a/extension/src/styles.css
+++ b/extension/src/styles.css
@@ -36,7 +36,3 @@ body {
   color: var(--text-color);
   background-color: var(--bg-color);
 }
-
-header {
-  border-bottom: 1px solid var(--border-color);
-}


### PR DESCRIPTION
# 관련 이슈

close #92 

# 소요 시간 (1 뽀모 : 25분)

1 뽀모

# 작업 내용 

![status](https://github.com/user-attachments/assets/193177e7-3fc8-42c9-9298-c0146abd42f0)

header 영역에서 border-bottom 을 제거하고 `reference` 키에서 사용 하고 있는 용량을 나타내는 `StatusVolumeBar` 컴포넌트를 생성 했습니다. 

# 작업 시 겪은 이슈

# 관련 레퍼런스
