### PR TITLE
[Feat] 접기 버튼 상하 패딩 2px 로 감소

### DIFF
--- a/extension/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
+++ b/extension/src/widgets/reference/ui/UnAttachedReferenceContainer.tsx
@@ -24,6 +24,7 @@ export const UnAttachedReferenceContainer = () => {
           </span>
         </h2>
         <Button
+          className="py-[2px]"
           onClick={() => {
             setChromeStorage((prev) => ({
               ...prev,


### PR DESCRIPTION
# 관련 이슈

close #94 

# 소요 시간 (1 뽀모 : 25분)

0.1뽀모

# 작업 내용 

![image](https://github.com/user-attachments/assets/96abb165-8c8c-4c57-8a4e-659b3e8bfbb8)

접기 버튼의 상하 패딩의 크기를  1rem 에서 2px 로 대폭 감소시켰습니다. 너무 뚱뚱해 

# 작업 시 겪은 이슈

# 관련 레퍼런스
