### PR TITLE
[Hotfix] 글쓰기 페이지에서 콘텐트 스크립트 인젝 되지 않은 경우 새로고침 되지 않던 버그 수정

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -72,10 +72,6 @@ chrome.runtime.onMessage.addListener(
       case "NotifyError":
         notifyError(message.data as string, sendResponse);
         break;
-      case "ReloadPage":
-        chrome.tabs.reload(tab.id);
-        sendResponse({ status: "ok" });
-        break;
       case "NotifyConvertProcessSuccess":
         const { data } = message as RequestMessage<number[]>;
 

--- a/extension/src/features/reference/ui/AutoConvertingToggle.tsx
+++ b/extension/src/features/reference/ui/AutoConvertingToggle.tsx
@@ -1,6 +1,7 @@
 import { useChromeStorage, useTab } from "@/shared/store";
 import styles from "./styles.module.css";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { isVelogWritePage } from "@/shared/lib";
 
 export const AutoConvertingToggle = () => {
   const {
@@ -8,24 +9,15 @@ export const AutoConvertingToggle = () => {
     setChromeStorage,
   } = useChromeStorage();
   const tab = useTab();
-  const [isAutoConvertingDisabled, setIsAutoConvertingDisabled] =
-    useState<boolean>(false);
 
   useEffect(() => {
     if (!tab) {
       return;
     }
 
-    if (tab.url.includes("https://velog.io/write") && !isContentScriptEnabled) {
-      setIsAutoConvertingDisabled(true);
-      setChromeStorage((prev) => ({
-        ...prev,
-        autoConverting: false,
-      }));
-      return;
+    if (isVelogWritePage(tab) && !isContentScriptEnabled) {
+      chrome.tabs.reload(tab.id);
     }
-
-    setIsAutoConvertingDisabled(false);
   }, [tab, isContentScriptEnabled]);
 
   return (
@@ -46,7 +38,6 @@ export const AutoConvertingToggle = () => {
               autoConverting: !prev.autoConverting,
             }));
           }}
-          disabled={isAutoConvertingDisabled}
         />
         <span className={styles.toggleSlider} />
       </div>

--- a/extension/src/features/reference/ui/ConvertToReferenceButton.tsx
+++ b/extension/src/features/reference/ui/ConvertToReferenceButton.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@/shared/ui/button";
 import { useChromeStorage, useTab } from "@/shared/store";
-import { sendMessageToBackground } from "@/shared/lib";
+import { isVelogWritePage, sendMessageToBackground } from "@/shared/lib";
 
 export const ConvertToReferenceButton = () => {
-  const { chromeStorage } = useChromeStorage();
+  const {
+    chromeStorage: { isContentScriptEnabled },
+  } = useChromeStorage();
   const tab = useTab();
-
-  const isVelogWritePage = tab?.url.includes("https://velog.io/write");
 
   const handleClick = async () => {
     if (!tab) {
@@ -39,7 +39,7 @@ export const ConvertToReferenceButton = () => {
     <Button
       onClick={handleClick}
       className="flex-grow"
-      disabled={!(isVelogWritePage && chromeStorage.isContentScriptEnabled)}
+      disabled={!(isVelogWritePage(tab) && isContentScriptEnabled)}
     >
       텍스트 변환
     </Button>

--- a/extension/src/shared/lib/tab.ts
+++ b/extension/src/shared/lib/tab.ts
@@ -1,2 +1,9 @@
 export const isTab = (tab: chrome.tabs.Tab | undefined): tab is Tab =>
   !!tab && !!tab.id && !!tab.url && !!tab.title;
+
+export const isVelogWritePage = (tab: Tab | null) => {
+  if (!tab) {
+    return false;
+  }
+  return tab.url.includes("https://velog.io/write");
+};


### PR DESCRIPTION
# 관련 이슈

close #106 

# 소요 시간 (1 뽀모 : 25분)

1.5뽀모

# 작업 내용 

- TabProvider 에서 isTab 이 아닌 경우 알림 기능 없이 null로 탭을 상태 변경 하도록 수정
- velog/write 페이지에서 새로고침 되지 않던 버그 수정
- 불필요한 background 에서 ReloadPage 메시지 핸들러 제거

# 작업 시 겪은 이슈

# 관련 레퍼런스
