### PR TITLE
[Feat] chrome.storage.local 이용하여 메모 기능 추가

### DIFF
--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -28,7 +28,7 @@ declare global {
 
   type ReferenceData = UnAttachedReferenceData | AttachedReferenceData;
 
-  interface ChromeStorage {
+  interface ChromeSyncStorage {
     reference: ReferenceData[];
     autoConverting: boolean;
     isDarkMode: boolean;

--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -36,9 +36,7 @@ declare global {
     isUnAttachedReferenceVisible: boolean;
   }
 
-  interface ChromeLocalStorage {
-    [key in string]: string;
-  }
+  type ChromeLocalStorage = Record<string, string>;
 
   interface Tab extends chrome.tabs.Tab {
     id: NonNullable<chrome.tabs.Tab["id"]>;

--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -36,6 +36,10 @@ declare global {
     isUnAttachedReferenceVisible: boolean;
   }
 
+  interface ChromeLocalStorage {
+    [key in string]: string;
+  }
+
   interface Tab extends chrome.tabs.Tab {
     id: NonNullable<chrome.tabs.Tab["id"]>;
     url: NonNullable<chrome.tabs.Tab["url"]>;

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 import { convertNumberToReference } from "./features/reference/model";
-import { chromeStorageInitialValue } from "./shared/store";
+import { chromeSyncStorageInitialValue } from "./shared/store";
 import { isTab } from "./shared/lib";
 
 browser.runtime.onInstalled.addListener(async (details) => {
@@ -19,7 +19,7 @@ browser.runtime.onInstalled.addListener(async (details) => {
 
   const prevStorageValue = await chrome.storage.sync.get(null);
   chrome.storage.sync.set({
-    ...chromeStorageInitialValue,
+    ...chromeSyncStorageInitialValue,
     ...prevStorageValue,
   });
 });
@@ -85,7 +85,7 @@ chrome.runtime.onMessage.addListener(
 
         prevUsedReferenceIds = data;
 
-        chrome.storage.sync.get<ChromeStorage>("reference", (storage) => {
+        chrome.storage.sync.get<ChromeSyncStorage>("reference", (storage) => {
           const { reference } = storage;
           const updatedReference = reference.map((referenceData) =>
             referenceData.isWritten

--- a/extension/src/contentScript.ts
+++ b/extension/src/contentScript.ts
@@ -52,7 +52,7 @@ const handleAutoConverting = (changes: chrome.storage.StorageChange) => {
   }
 };
 
-let chromeStorage: ChromeStorage | null = null;
+let chromeStorage: ChromeSyncStorage | null = null;
 
 const syncChromeStorage = (changes: chrome.storage.StorageChange) => {
   const [[key, value]] = Object.entries(changes);
@@ -61,7 +61,7 @@ const syncChromeStorage = (changes: chrome.storage.StorageChange) => {
   console.table({ key, value });
 
   if (!chromeStorage) {
-    chrome.storage.sync.get<ChromeStorage>(null, (data) => {
+    chrome.storage.sync.get<ChromeSyncStorage>(null, (data) => {
       chromeStorage = data;
       console.log("chromeStorage 동기화 완료", chromeStorage);
     });
@@ -79,7 +79,7 @@ const syncChromeStorage = (changes: chrome.storage.StorageChange) => {
   console.groupEnd();
 };
 
-chrome.storage.sync.get<ChromeStorage>(null, (data) => {
+chrome.storage.sync.get<ChromeSyncStorage>(null, (data) => {
   chrome.storage.sync.onChanged.addListener(syncChromeStorage);
   chrome.storage.sync.onChanged.addListener(handleAutoConverting);
 
@@ -116,7 +116,7 @@ window.addEventListener("unload", () => {
   }));
 
   const { reference } =
-    await chrome.storage.sync.get<ChromeStorage>("reference");
+    await chrome.storage.sync.get<ChromeSyncStorage>("reference");
 
   // 만약 사용 된 데이터가 없고 attachedReferenceData 모두 isUsed가 false 라면
   // 상태를 변경하지 않고 early return 합니다.

--- a/extension/src/features/reference/model/convertReference.ts
+++ b/extension/src/features/reference/model/convertReference.ts
@@ -6,7 +6,7 @@ export const convertNumberToReference = async (
   sendResponse: (response: ResponseMessage) => void
 ) => {
   const { reference } =
-    await chrome.storage.sync.get<ChromeStorage>("reference");
+    await chrome.storage.sync.get<ChromeSyncStorage>("reference");
 
   const [result] = await chrome.scripting.executeScript({
     target: { tabId },

--- a/extension/src/features/reference/ui/AutoConvertingToggle.tsx
+++ b/extension/src/features/reference/ui/AutoConvertingToggle.tsx
@@ -1,11 +1,11 @@
-import { useChromeStorage, useTab } from "@/shared/store";
+import { useChromeSyncStorage, useTab } from "@/shared/store";
 import styles from "./styles.module.css";
 import { memo, useEffect } from "react";
 import { isVelogWritePage } from "@/shared/lib";
 
 export const AutoConvertingToggle = memo(() => {
-  const autoConverting = useChromeStorage((state) => state.autoConverting);
-  const isContentScriptEnabled = useChromeStorage(
+  const autoConverting = useChromeSyncStorage((state) => state.autoConverting);
+  const isContentScriptEnabled = useChromeSyncStorage(
     (state) => state.isContentScriptEnabled
   );
 
@@ -34,7 +34,7 @@ export const AutoConvertingToggle = memo(() => {
           className={styles.checkBox}
           checked={autoConverting}
           onChange={() => {
-            useChromeStorage.setState({ autoConverting: !autoConverting });
+            useChromeSyncStorage.setState({ autoConverting: !autoConverting });
           }}
         />
         <span className={styles.toggleSlider} />

--- a/extension/src/features/reference/ui/ConvertToReferenceButton.tsx
+++ b/extension/src/features/reference/ui/ConvertToReferenceButton.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@/shared/ui/button";
-import { useChromeStorage, useTab } from "@/shared/store";
+import { useChromeSyncStorage, useTab } from "@/shared/store";
 import { isVelogWritePage, sendMessageToBackground } from "@/shared/lib";
 
 export const ConvertToReferenceButton = () => {
-  const isContentScriptEnabled = useChromeStorage(
+  const isContentScriptEnabled = useChromeSyncStorage(
     (state) => state.isContentScriptEnabled
   );
   const tab = useTab();

--- a/extension/src/features/reference/ui/CopyReferenceListButton.tsx
+++ b/extension/src/features/reference/ui/CopyReferenceListButton.tsx
@@ -1,8 +1,8 @@
-import { useChromeStorage } from "@/shared/store";
+import { useChromeSyncStorage } from "@/shared/store";
 import { Button } from "@/shared/ui/button";
 
 export const CopyReferenceListButton = () => {
-  const reference = useChromeStorage((state) => state.reference);
+  const reference = useChromeSyncStorage((state) => state.reference);
 
   const handleCopyReferenceList = () => {
     const attachedReferences = reference

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -1,8 +1,8 @@
-import React, { ChangeEvent, createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useState } from "react";
 import styles from "./styles.module.css";
 import { useChromeSyncStorage } from "@/shared/store/chromeSyncStorage";
 import { Button, IconButton } from "@/shared/ui/button";
-import { Text } from "@/shared/ui/Text";
+import { useChromeLocalStorage } from "@/shared/store";
 
 interface ReferenceContext {
   reference: ReferenceData;
@@ -266,20 +266,26 @@ const MovePageButton = () => {
 };
 
 const MemoArea = () => {
-  const { reference } = useReferenceContext();
-  const [text, setText] = useState<string>("");
-  const handleChange = ({ target }: ChangeEvent<HTMLTextAreaElement>) => {
-    setText(target.value);
-  };
+  const {
+    reference: { url },
+  } = useReferenceContext();
+  const text = useChromeLocalStorage((state) => state[url] || "");
 
   return (
     <textarea
-      name={`${reference.url}-memo`}
-      id={reference.url}
+      name={`${url}-memo`}
+      id={url}
       onClick={(event) => {
         event.stopPropagation();
       }}
-      onChange={handleChange}
+      onChange={({ target }) => {
+        useChromeLocalStorage.dispatchAction({
+          type: "set",
+          key: url,
+          value: target.value,
+        });
+      }}
+      defaultValue={text}
       className="w-full text-[0.9rem] focus:outline-none bg-transparent rounded-lg p-2 h-24"
     />
   );

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -307,8 +307,9 @@ const MemoArea = () => {
       onChange={({ target }) => {
         useChromeLocalStorage.dispatchAction({
           type: "set",
-          key: url,
-          value: target.value,
+          data: {
+            [url]: target.value,
+          },
         });
       }}
       defaultValue={text}

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -191,6 +191,11 @@ const RemoveButton = () => {
           }),
       };
     });
+
+    useChromeLocalStorage.dispatchAction({
+      type: "remove",
+      key: reference.url,
+    });
   };
 
   return (

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -271,25 +271,17 @@ const MemoArea = () => {
   const handleChange = ({ target }: ChangeEvent<HTMLTextAreaElement>) => {
     setText(target.value);
   };
-  const maxLength = 500; // TODO 한 키 당 저장 가능한 text 구하기
 
   return (
-    <div className="flex flex-col items-end">
-      <textarea
-        name={`${reference.url}-memo`}
-        id={reference.url}
-        onClick={(event) => {
-          event.stopPropagation();
-        }}
-        onChange={handleChange}
-        className="w-full text-[0.9rem] focus:outline-none bg-transparent rounded-lg p-2 h-24"
-      />
-      <Text p type="secondary" className="flex gap-1 text-[0.7rem]">
-        <span>{text.length}</span>
-        <span>/</span>
-        <span>{maxLength}</span>
-      </Text>
-    </div>
+    <textarea
+      name={`${reference.url}-memo`}
+      id={reference.url}
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+      onChange={handleChange}
+      className="w-full text-[0.9rem] focus:outline-none bg-transparent rounded-lg p-2 h-24"
+    />
   );
 };
 

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -1,7 +1,8 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { ChangeEvent, createContext, useContext, useState } from "react";
 import styles from "./styles.module.css";
 import { useChromeStorage } from "@/shared/store/chromeStorage";
 import { Button, IconButton } from "@/shared/ui/button";
+import { Text } from "@/shared/ui/Text";
 
 interface ReferenceContext {
   reference: ReferenceData;
@@ -35,7 +36,7 @@ const ReferenceItemWrapper = ({
       value={{ reference, setChromeStorage: useChromeStorage.setState }}
     >
       <li
-        className={`reference cursor-pointer border-b py-1 flex flex-col justify-center gap-2 ${className}`}
+        className={`reference cursor-pointer py-1 flex flex-col justify-center gap-2 ${className}`}
         onClick={onClick}
       >
         {children}
@@ -264,6 +265,34 @@ const MovePageButton = () => {
   );
 };
 
+const MemoArea = () => {
+  const { reference } = useReferenceContext();
+  const [text, setText] = useState<string>("");
+  const handleChange = ({ target }: ChangeEvent<HTMLTextAreaElement>) => {
+    setText(target.value);
+  };
+  const maxLength = 500; // TODO 한 키 당 저장 가능한 text 구하기
+
+  return (
+    <div className="flex flex-col items-end">
+      <textarea
+        name={`${reference.url}-memo`}
+        id={reference.url}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+        onChange={handleChange}
+        className="w-full text-[0.9rem] focus:outline-none bg-transparent rounded-lg p-2 h-24"
+      />
+      <Text p type="secondary" className="flex gap-1 text-[0.7rem]">
+        <span>{text.length}</span>
+        <span>/</span>
+        <span>{maxLength}</span>
+      </Text>
+    </div>
+  );
+};
+
 export const Reference = Object.assign(ReferenceItemWrapper, {
   Favicon,
   Title,
@@ -274,4 +303,5 @@ export const Reference = Object.assign(ReferenceItemWrapper, {
   CopyLinkWithTextButton,
   MovePageButton,
   CustomButton,
+  MemoArea,
 });

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -307,8 +307,8 @@ const MemoArea = () => {
       onChange={({ target }) => {
         useChromeLocalStorage.dispatchAction({
           type: "set",
-          data: {
-            [url]: target.value,
+          setter: () => {
+            return { [url]: target.value };
           },
         });
       }}

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import styles from "./styles.module.css";
 import { useChromeSyncStorage } from "@/shared/store/chromeSyncStorage";
 import { Button, IconButton } from "@/shared/ui/button";
@@ -275,9 +281,24 @@ const MemoArea = () => {
     reference: { url },
   } = useReferenceContext();
   const text = useChromeLocalStorage((state) => state[url] || "");
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const synchronizeText = () => {
+      if (textAreaRef.current) {
+        textAreaRef.current.value = useChromeLocalStorage.getState()[url] || "";
+      }
+    };
+
+    window.addEventListener("focus", synchronizeText);
+    return () => {
+      window.removeEventListener("focus", synchronizeText);
+    };
+  }, []);
 
   return (
     <textarea
+      ref={textAreaRef}
       name={`${url}-memo`}
       id={url}
       onClick={(event) => {

--- a/extension/src/features/reference/ui/Reference.tsx
+++ b/extension/src/features/reference/ui/Reference.tsx
@@ -1,12 +1,12 @@
 import React, { ChangeEvent, createContext, useContext, useState } from "react";
 import styles from "./styles.module.css";
-import { useChromeStorage } from "@/shared/store/chromeStorage";
+import { useChromeSyncStorage } from "@/shared/store/chromeSyncStorage";
 import { Button, IconButton } from "@/shared/ui/button";
 import { Text } from "@/shared/ui/Text";
 
 interface ReferenceContext {
   reference: ReferenceData;
-  setChromeStorage: typeof useChromeStorage.setState;
+  setChromeStorage: typeof useChromeSyncStorage.setState;
 }
 
 const ReferenceProvider = createContext<ReferenceContext | null>(null);
@@ -33,7 +33,7 @@ const ReferenceItemWrapper = ({
 }: ReferenceProps) => {
   return (
     <ReferenceProvider.Provider
-      value={{ reference, setChromeStorage: useChromeStorage.setState }}
+      value={{ reference, setChromeStorage: useChromeSyncStorage.setState }}
     >
       <li
         className={`reference cursor-pointer py-1 flex flex-col justify-center gap-2 ${className}`}

--- a/extension/src/features/reference/ui/ReferenceEdit.tsx
+++ b/extension/src/features/reference/ui/ReferenceEdit.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/shared/ui/button";
 import { Reference } from "./Reference";
 import { useState } from "react";
-import { useChromeStorage } from "@/shared/store";
+import { useChromeSyncStorage } from "@/shared/store";
 
 interface ReferenceEditProps {
   reference: ReferenceData;
@@ -14,7 +14,7 @@ export const ReferenceEdit = ({
   onResolveEdit,
   className = "",
 }: ReferenceEditProps) => {
-  const setChromeStorage = useChromeStorage.setState;
+  const setChromeStorage = useChromeSyncStorage.setState;
 
   const [title, setTitle] = useState<string>(() => reference.title);
 

--- a/extension/src/features/reference/ui/ReferenceSaveButton.tsx
+++ b/extension/src/features/reference/ui/ReferenceSaveButton.tsx
@@ -1,12 +1,12 @@
 import { isTab, sendMessageToBackground } from "@/shared/lib";
 import { useSaveErrorUrl } from "@/shared/store";
-import { useChromeStorage } from "@/shared/store/chromeStorage";
+import { useChromeSyncStorage } from "@/shared/store/chromeSyncStorage";
 import { Button } from "@/shared/ui/button";
 
 // TODO : 로딩 처리 하기
 export const ReferenceSaveButton = () => {
-  const reference = useChromeStorage((state) => state.reference);
-  const setChromeStorage = useChromeStorage.setState;
+  const reference = useChromeSyncStorage((state) => state.reference);
+  const setChromeStorage = useChromeSyncStorage.setState;
   const { errorUrl, setErrorUrl } = useSaveErrorUrl();
 
   const handleSaveReference = async () => {

--- a/extension/src/features/reference/ui/ResetReferenceButton.tsx
+++ b/extension/src/features/reference/ui/ResetReferenceButton.tsx
@@ -1,8 +1,8 @@
-import { useChromeStorage } from "@/shared/store/chromeStorage";
+import { useChromeSyncStorage } from "@/shared/store/chromeSyncStorage";
 import { Button } from "@/shared/ui/button";
 
 export const ResetReferenceButton = () => {
-  const setChromeStorage = useChromeStorage.setState;
+  const setChromeStorage = useChromeSyncStorage.setState;
 
   const handleResetReference = () => {
     setChromeStorage((prev) => ({

--- a/extension/src/features/utils/ui/DarkModeToggle.tsx
+++ b/extension/src/features/utils/ui/DarkModeToggle.tsx
@@ -1,10 +1,10 @@
-import { useChromeStorage } from "@/shared/store";
+import { useChromeSyncStorage } from "@/shared/store";
 import styles from "./styles.module.css";
 import { useEffect } from "react";
 
 export const DarkModeToggle = () => {
-  const isDarkMode = useChromeStorage((state) => state.isDarkMode);
-  const setChromeStorage = useChromeStorage.setState;
+  const isDarkMode = useChromeSyncStorage((state) => state.isDarkMode);
+  const setChromeStorage = useChromeSyncStorage.setState;
 
   const handleToggle = () => {
     setChromeStorage((prevStorage) => ({

--- a/extension/src/index.tsx
+++ b/extension/src/index.tsx
@@ -1,13 +1,13 @@
 import ReactDOM from "react-dom/client";
 import { SidePanelPage } from "./pages";
-import { ChromeStorageUpdater } from "./shared/store/chromeStorage";
+import { ChromeSyncStorageUpdater } from "./shared/store/chromeSyncStorage";
 import { SaveErrorProvider, TabProvider } from "./shared/store";
 import "./styles.css";
 
 ReactDOM.createRoot(document.querySelector("#root")!).render(
   <TabProvider>
     <SaveErrorProvider>
-      <ChromeStorageUpdater />
+      <ChromeSyncStorageUpdater />
       <SidePanelPage />
     </SaveErrorProvider>
   </TabProvider>

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RefNote",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "블로깅에 필요한 레퍼런스들을 가볍고 편하게 저장 및 사용 할 수 있는 확장 프로그램입니다.",
   "minimum_chrome_version": "116",
   "{{chrome}}.manifest_version": 3,

--- a/extension/src/pages/SidePanel.tsx
+++ b/extension/src/pages/SidePanel.tsx
@@ -7,8 +7,21 @@ import {
 } from "@/features/reference/ui";
 import { DarkModeToggle, StorageVolumeBar } from "@/features/utils/ui";
 import { UnExpectedErrorBoundary } from "./errorBoundary";
+import { useEffect } from "react";
+import { useChromeLocalStorage } from "@/shared/store";
 
 export const SidePanelPage = () => {
+  useEffect(() => {
+    const synchronizeStore = () => {
+      useChromeLocalStorage.synchronizeStore();
+    };
+
+    window.addEventListener("focus", synchronizeStore);
+    return () => {
+      window.removeEventListener("focus", synchronizeStore);
+    };
+  }, []);
+
   return (
     <UnExpectedErrorBoundary>
       <header className="flex flex-col gap-2 ">

--- a/extension/src/shared/lib/createLocalStore.ts
+++ b/extension/src/shared/lib/createLocalStore.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+
+type ChromeLocalStorageAction<T, K extends keyof T = keyof T> =
+  | {
+      type: "clear";
+    }
+  | {
+      type: "set";
+      key: K;
+      value: T[K];
+    }
+  | {
+      type: "remove";
+      key: K;
+    };
+
+export const createLocalStore = <Store extends object>(
+  initialState: Store | (() => Store)
+) => {
+  let store =
+    typeof initialState === "function" ? initialState() : initialState;
+
+  // 초기 호출 시 store 는 chrome.storage.local 의 값으로 초기화 됨
+
+  chrome.storage.local.get(null, (store) => {
+    Object.assign(store, store);
+    callbacks.forEach((callback) => callback());
+  });
+
+  const callbacks = new Set<() => void>();
+
+  const subscribe = (callback: () => void): (() => void) => {
+    callbacks.add(callback);
+    return () => callbacks.delete(callback);
+  };
+
+  const getState = () => ({ ...store });
+
+  const dispatchAction = (action: ChromeLocalStorageAction<Store>) => {
+    switch (action.type) {
+      case "clear":
+        chrome.storage.local.clear();
+        break;
+      case "set":
+        chrome.storage.local.set({ [action.key]: action.value });
+        break;
+      case "remove":
+        chrome.storage.local.remove(action.key);
+        break;
+    }
+  };
+
+  // chrome.storage.local 의 값에 따라 store 가 변경 되도록 함
+
+  chrome.storage.onChanged.addListener((changes, namespace) => {
+    if (namespace !== "local") {
+      return;
+    }
+
+    const changeEntries = Object.entries(changes).map(
+      ([key, { newValue }]) => ({
+        key,
+        newValue,
+      })
+    );
+
+    changeEntries.forEach(({ key, newValue }) => {
+      if (!newValue) {
+        delete store[key as keyof Store];
+      }
+      store[key as keyof Store] = newValue;
+    });
+
+    callbacks.forEach((callback) => callback());
+  });
+
+  const useStore = <R>(selector: (state: Store) => R) => {
+    const [state, _setState] = useState(() => selector(store));
+
+    useEffect(() => {
+      const unsubscribe = subscribe(() => {
+        _setState(selector(store));
+      });
+
+      return unsubscribe;
+    }, []);
+
+    return state;
+  };
+
+  useStore.dispatchAction = dispatchAction;
+  useStore.getState = getState;
+
+  return useStore;
+};

--- a/extension/src/shared/lib/createLocalStore.ts
+++ b/extension/src/shared/lib/createLocalStore.ts
@@ -37,6 +37,12 @@ export const createLocalStore = <Store extends object>(
   const getState = () => ({ ...store });
 
   const dispatchAction = (action: ChromeLocalStorageAction<Store>) => {
+    if (import.meta.env.DEV) {
+      console.group("ChromeLocalStorage Action Dispatched");
+      console.log(action);
+      console.groupEnd();
+    }
+
     switch (action.type) {
       case "clear":
         chrome.storage.local.clear();
@@ -65,11 +71,14 @@ export const createLocalStore = <Store extends object>(
     );
 
     changeEntries.forEach(({ key, newValue }) => {
-      if (!newValue) {
-        delete store[key as keyof Store];
-      }
       store[key as keyof Store] = newValue;
     });
+
+    if (import.meta.env.DEV) {
+      console.group("변경 이후 chromeLocalStorage");
+      console.table(store);
+      console.groupEnd();
+    }
 
     callbacks.forEach((callback) => callback());
   });

--- a/extension/src/shared/lib/createLocalStore.ts
+++ b/extension/src/shared/lib/createLocalStore.ts
@@ -45,7 +45,7 @@ export const createLocalStore = <Store extends object>(
 
     switch (action.type) {
       case "clear":
-        chrome.storage.local.clear();
+        chrome.storage.local.set(initialState);
         break;
       case "set":
         chrome.storage.local.set({ [action.key]: action.value });

--- a/extension/src/shared/lib/createLocalStore.ts
+++ b/extension/src/shared/lib/createLocalStore.ts
@@ -6,9 +6,7 @@ type ChromeLocalStorageAction<T> =
     }
   | {
       type: "set";
-      data: {
-        [key in keyof T]: T[key];
-      };
+      setter: (storage: T) => Partial<T>;
     }
   | {
       type: "remove";
@@ -55,7 +53,7 @@ export const createLocalStore = <Store extends object>(
         chrome.storage.local.set(initialState);
         break;
       case "set":
-        chrome.storage.local.set(action.data);
+        chrome.storage.local.set(action.setter(store));
         break;
       case "remove":
         chrome.storage.local.remove(action.key);

--- a/extension/src/shared/lib/createLocalStore.ts
+++ b/extension/src/shared/lib/createLocalStore.ts
@@ -20,12 +20,18 @@ export const createLocalStore = <Store extends object>(
   let store =
     typeof initialState === "function" ? initialState() : initialState;
 
-  // 초기 호출 시 store 는 chrome.storage.local 의 값으로 초기화 됨
+  const synchronizeStore = () => {
+    chrome.storage.local.get(null, (storage) => {
+      if (import.meta.env.DEV) {
+        console.group("동기화를 시행 할 chromeLocalStorage 값");
+        console.table(store);
+        console.groupEnd();
+      }
 
-  chrome.storage.local.get(null, (localStorage) => {
-    Object.assign(store, localStorage);
-    callbacks.forEach((callback) => callback());
-  });
+      Object.assign(store, storage);
+      callbacks.forEach((callback) => callback());
+    });
+  };
 
   const callbacks = new Set<() => void>();
 
@@ -99,6 +105,9 @@ export const createLocalStore = <Store extends object>(
 
   useStore.dispatchAction = dispatchAction;
   useStore.getState = getState;
+  useStore.synchronizeStore = synchronizeStore;
+
+  synchronizeStore();
 
   return useStore;
 };

--- a/extension/src/shared/lib/createLocalStore.ts
+++ b/extension/src/shared/lib/createLocalStore.ts
@@ -22,8 +22,8 @@ export const createLocalStore = <Store extends object>(
 
   // 초기 호출 시 store 는 chrome.storage.local 의 값으로 초기화 됨
 
-  chrome.storage.local.get(null, (store) => {
-    Object.assign(store, store);
+  chrome.storage.local.get(null, (localStorage) => {
+    Object.assign(store, localStorage);
     callbacks.forEach((callback) => callback());
   });
 

--- a/extension/src/shared/lib/createLocalStore.ts
+++ b/extension/src/shared/lib/createLocalStore.ts
@@ -1,17 +1,18 @@
 import { useEffect, useState } from "react";
 
-type ChromeLocalStorageAction<T, K extends keyof T = keyof T> =
+type ChromeLocalStorageAction<T> =
   | {
       type: "clear";
     }
   | {
       type: "set";
-      key: K;
-      value: T[K];
+      data: {
+        [key in keyof T]: T[key];
+      };
     }
   | {
       type: "remove";
-      key: K;
+      key: keyof T;
     };
 
 export const createLocalStore = <Store extends object>(
@@ -54,7 +55,7 @@ export const createLocalStore = <Store extends object>(
         chrome.storage.local.set(initialState);
         break;
       case "set":
-        chrome.storage.local.set({ [action.key]: action.value });
+        chrome.storage.local.set(action.data);
         break;
       case "remove":
         chrome.storage.local.remove(action.key);

--- a/extension/src/shared/lib/createSyncStore.ts
+++ b/extension/src/shared/lib/createSyncStore.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
-
-type Selector<T, R> = (state: T) => R;
+import type { Selector } from "./types";
 
 export const createSyncStore = <Store extends object>(
   initialState: Store | (() => Store)

--- a/extension/src/shared/lib/createSyncStore.ts
+++ b/extension/src/shared/lib/createSyncStore.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 type Selector<T, R> = (state: T) => R;
 
-export const createStore = <Store extends object>(
+export const createSyncStore = <Store extends object>(
   initialState: Store | (() => Store)
 ) => {
   let store =

--- a/extension/src/shared/lib/index.ts
+++ b/extension/src/shared/lib/index.ts
@@ -1,3 +1,5 @@
 export * from "./message";
 export * from "./tab";
 export * from "./createSyncStore";
+export * from "./createLocalStore";
+export * from "./types";

--- a/extension/src/shared/lib/index.ts
+++ b/extension/src/shared/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./message";
 export * from "./tab";
+export * from "./createSyncStore";

--- a/extension/src/shared/lib/types.ts
+++ b/extension/src/shared/lib/types.ts
@@ -1,0 +1,1 @@
+export type Selector<T, R> = (state: T) => R;

--- a/extension/src/shared/store/chromeLocalStorage.tsx
+++ b/extension/src/shared/store/chromeLocalStorage.tsx
@@ -1,0 +1,3 @@
+import { createLocalStore } from "../lib";
+
+export const useChromeLocalStorage = createLocalStore<ChromeLocalStorage>({});

--- a/extension/src/shared/store/chromeSyncStorage.tsx
+++ b/extension/src/shared/store/chromeSyncStorage.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useRef } from "react";
 import { createSyncStore } from "../lib";
 
-type Synchronize = (
-  changes: chrome.storage.StorageChange,
-  namespace: chrome.storage.AreaName
-) => void;
-
 export const chromeSyncStorageInitialValue: ChromeSyncStorage = {
   reference: [],
   autoConverting: false,
@@ -33,7 +28,10 @@ export const ChromeSyncStorageUpdater = () => {
     // 서로 다른 컨텍스트를 가진 탭에서 chrome.storage.sync 의 변화에 맞춰
     // 리액트의 메모리도 업데이트 될 수 있도록 onChangeHandler 등록
 
-    const onSynchronize: Synchronize = (changes, namespace) => {
+    const onSynchronize = (
+      changes: chrome.storage.StorageChange,
+      namespace: chrome.storage.AreaName
+    ) => {
       if (namespace !== "sync") {
         return;
       }

--- a/extension/src/shared/store/chromeSyncStorage.tsx
+++ b/extension/src/shared/store/chromeSyncStorage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { createStore } from "../lib/createStore";
+import { createSyncStore } from "../lib";
 
 type Synchronize = (
   changes: chrome.storage.StorageChange,
@@ -14,7 +14,9 @@ export const chromeSyncStorageInitialValue: ChromeSyncStorage = {
   isUnAttachedReferenceVisible: true,
 };
 
-export const useChromeSyncStorage = createStore(chromeSyncStorageInitialValue);
+export const useChromeSyncStorage = createSyncStore(
+  chromeSyncStorageInitialValue
+);
 
 export const ChromeSyncStorageUpdater = () => {
   const store = useChromeSyncStorage((state) => state);

--- a/extension/src/shared/store/chromeSyncStorage.tsx
+++ b/extension/src/shared/store/chromeSyncStorage.tsx
@@ -6,7 +6,7 @@ type Synchronize = (
   namespace: chrome.storage.AreaName
 ) => void;
 
-export const chromeStorageInitialValue: ChromeStorage = {
+export const chromeSyncStorageInitialValue: ChromeSyncStorage = {
   reference: [],
   autoConverting: false,
   isDarkMode: false,
@@ -14,10 +14,10 @@ export const chromeStorageInitialValue: ChromeStorage = {
   isUnAttachedReferenceVisible: true,
 };
 
-export const useChromeStorage = createStore(chromeStorageInitialValue);
+export const useChromeSyncStorage = createStore(chromeSyncStorageInitialValue);
 
-export const ChromeStorageUpdater = () => {
-  const store = useChromeStorage((state) => state);
+export const ChromeSyncStorageUpdater = () => {
+  const store = useChromeSyncStorage((state) => state);
   const initializeFlag = useRef<boolean>(false);
   const synchronizeFlag = useRef<boolean>(false);
 
@@ -25,7 +25,7 @@ export const ChromeStorageUpdater = () => {
     // 초기 마운트 시 chrome storage에서 값을 가져와서 store에 저장
 
     chrome.storage.sync.get(null, (store) => {
-      useChromeStorage.setState(store as ChromeStorage);
+      useChromeSyncStorage.setState(store as ChromeSyncStorage);
     });
 
     // 서로 다른 컨텍스트를 가진 탭에서 chrome.storage.sync 의 변화에 맞춰
@@ -38,13 +38,13 @@ export const ChromeStorageUpdater = () => {
 
       const newState = Object.entries(changes).reduce(
         (newState, [key, { newValue }]) => {
-          newState[key as keyof ChromeStorage] = newValue;
+          newState[key as keyof ChromeSyncStorage] = newValue;
           return newState;
         },
-        {} as Partial<ChromeStorage>
+        {} as Partial<ChromeSyncStorage>
       );
 
-      useChromeStorage.setState(newState);
+      useChromeSyncStorage.setState(newState);
       synchronizeFlag.current = true;
     };
 

--- a/extension/src/shared/store/index.ts
+++ b/extension/src/shared/store/index.ts
@@ -1,3 +1,3 @@
-export * from "./chromeStorage";
+export * from "./chromeSyncStorage";
 export * from "./tab";
 export * from "./saveError";

--- a/extension/src/shared/store/index.ts
+++ b/extension/src/shared/store/index.ts
@@ -1,3 +1,4 @@
 export * from "./chromeSyncStorage";
 export * from "./tab";
 export * from "./saveError";
+export * from "./chromeLocalStorage";

--- a/extension/src/styles.css
+++ b/extension/src/styles.css
@@ -41,11 +41,20 @@ body {
   background-color: var(--bg-color);
 }
 
-.reference:hover {
+.reference {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.reference:hover:not(:has(textarea:hover)) {
   background-color: var(--hover-color);
 }
-.reference:active {
+
+.reference:active:not(:has(textarea:active)) {
   background-color: var(--active-color);
+}
+
+textarea {
+  border: 1px solid var(--border-color);
 }
 
 @keyframes blinkAnimation {

--- a/extension/src/widgets/reference/ui/ReferenceListWidget.tsx
+++ b/extension/src/widgets/reference/ui/ReferenceListWidget.tsx
@@ -1,5 +1,5 @@
 import { memo, useState } from "react";
-import { useChromeStorage, useSaveErrorUrl } from "@/shared/store";
+import { useChromeSyncStorage, useSaveErrorUrl } from "@/shared/store";
 import {
   AutoConvertingToggle,
   Reference,
@@ -97,10 +97,10 @@ const UnAttachedReferenceList = ({
 };
 
 const UnAttachedReferenceListFoldButton = memo(() => {
-  const isUnAttachedReferenceVisible = useChromeStorage(
+  const isUnAttachedReferenceVisible = useChromeSyncStorage(
     (state) => state.isUnAttachedReferenceVisible
   );
-  const setChromeStorage = useChromeStorage.setState;
+  const setChromeStorage = useChromeSyncStorage.setState;
 
   return (
     <Button
@@ -204,8 +204,8 @@ const AttachedReferenceList = ({
 };
 
 export const ReferenceListWidget = () => {
-  const reference = useChromeStorage((state) => state.reference);
-  const isUnAttachedReferenceVisible = useChromeStorage(
+  const reference = useChromeSyncStorage((state) => state.reference);
+  const isUnAttachedReferenceVisible = useChromeSyncStorage(
     (state) => state.isUnAttachedReferenceVisible
   );
 

--- a/extension/src/widgets/reference/ui/ReferenceListWidget.tsx
+++ b/extension/src/widgets/reference/ui/ReferenceListWidget.tsx
@@ -32,6 +32,8 @@ const UnAttachedReferenceList = ({
 }) => {
   const [clickedUrl, setClickedUrl] = useState<string>("");
   const [isEditUrl, setEditUrl] = useState<string>("");
+  const [isMemoOpen, setIsMemoOpen] = useState<boolean>(false);
+
   const { errorUrl } = useSaveErrorUrl();
 
   const handleClickUrl = (url: string) => {
@@ -64,19 +66,27 @@ const UnAttachedReferenceList = ({
               <Reference.RemoveButton />
             </div>
             {reference.url === clickedUrl && (
-              <div className="flex flex-col gap-1">
-                <div className="flex gap-2 items-center">
-                  <Reference.CopyLinkButton />
-                  <Reference.CopyLinkWithTextButton />
-                  <Reference.MovePageButton />
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  <div className="flex gap-2 items-center">
+                    <Reference.CopyLinkButton />
+                    <Reference.CopyLinkWithTextButton />
+                    <Reference.MovePageButton />
+                  </div>
+                  <div className="flex w-full gap-2">
+                    <Reference.CustomButton
+                      onClick={() => setEditUrl(reference.url)}
+                    >
+                      제목 수정
+                    </Reference.CustomButton>
+                    <Reference.CustomButton
+                      onClick={() => setIsMemoOpen((prev) => !prev)}
+                    >
+                      {isMemoOpen ? "메모 닫기" : "메모 열기"}
+                    </Reference.CustomButton>
+                  </div>
                 </div>
-                <div className="flex w-full">
-                  <Reference.CustomButton
-                    onClick={() => setEditUrl(reference.url)}
-                  >
-                    제목 수정
-                  </Reference.CustomButton>
-                </div>
+                {isMemoOpen && <Reference.MemoArea />}
               </div>
             )}
           </Reference>
@@ -119,6 +129,7 @@ const AttachedReferenceList = ({
 }) => {
   const [clickedUrl, setClickedUrl] = useState<string>("");
   const [isEditUrl, setEditUrl] = useState<string>("");
+  const [isMemoOpen, setIsMemoOpen] = useState<boolean>(false);
   const { errorUrl } = useSaveErrorUrl();
 
   const handleClickUrl = (url: string) => {
@@ -162,19 +173,27 @@ const AttachedReferenceList = ({
               <Reference.RemoveButton />
             </div>
             {reference.url === clickedUrl && (
-              <div className="flex flex-col gap-1">
-                <div className="flex gap-2 items-center">
-                  <Reference.CopyLinkButton />
-                  <Reference.CopyLinkWithTextButton />
-                  <Reference.MovePageButton />
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1">
+                  <div className="flex gap-2 items-center">
+                    <Reference.CopyLinkButton />
+                    <Reference.CopyLinkWithTextButton />
+                    <Reference.MovePageButton />
+                  </div>
+                  <div className="flex w-full gap-2">
+                    <Reference.CustomButton
+                      onClick={() => setEditUrl(reference.url)}
+                    >
+                      제목 수정
+                    </Reference.CustomButton>
+                    <Reference.CustomButton
+                      onClick={() => setIsMemoOpen((prev) => !prev)}
+                    >
+                      {isMemoOpen ? "메모 닫기" : "메모 열기"}
+                    </Reference.CustomButton>
+                  </div>
                 </div>
-                <div className="flex w-full">
-                  <Reference.CustomButton
-                    onClick={() => setEditUrl(reference.url)}
-                  >
-                    제목 수정
-                  </Reference.CustomButton>
-                </div>
+                {isMemoOpen && <Reference.MemoArea />}
               </div>
             )}
           </Reference>

--- a/extension/tailwind.config.js
+++ b/extension/tailwind.config.js
@@ -43,8 +43,8 @@ export default {
           active: "#d0d0d0",
         },
         border: {
-          light: "#e9ecef",
-          dark: "#495057",
+          light: "#d1d6db",
+          dark: "#a0a0a0",
         },
       },
     },


### PR DESCRIPTION
# 관련 이슈
close #111 
# 소요 시간 (1 뽀모 : 25분)

4뽀모 

# 작업 내용 

![image](https://github.com/user-attachments/assets/9553c064-83e1-432e-9315-9263b1beb919)

메모 기능을 추가했습니다. 

메모에선 많은 양의 글을 메모 할 수 있도록 100kb , 항목 당 8kb 의 용량 제한이 있는 sync.storage 가 아닌 

10mb 의 용량이 제한이 있는 local.storage 를 사용했습니다. 

뭐 메모까지 동기화 될 필요는 없는거니까 ..  

- `useChromeStorage` -> `useChromeSyncStorage` 로 변경
- 'useChromeLocalStorage` 훅 생성 
- flux 패턴 이용하여 external storage 와 메모리 연결 
- window focus 시 메모리 상 storaeg 업데이트 하도록 수정 (메모 컴포넌트에서 동기화 위해선 필요했던 작업)




# 작업 시 겪은 이슈

# 관련 레퍼런스
